### PR TITLE
Fix compatibility issues with bash-3.x

### DIFF
--- a/konfig
+++ b/konfig
@@ -17,7 +17,6 @@
 [[ -n $DEBUG ]] && set -x
 
 set -eou pipefail
-IFS=$':\n\t'
 
 declare -a TMPFILES=()
 cleanup() {
@@ -73,10 +72,14 @@ error() {
 merge() {
     if [[ "$1" =~ ^-(.*) && "$1" != '-p' && "$1" != '--preserve-structure' ]]; then
       error "unrecognized flag \"$1\""
-    elif [[ "$1" == '-p' || "$1" == '--preserve-structure' ]]; then
-      KUBECONFIG="${*:2}" $KUBECTL config view --raw --merge
     else
-      KUBECONFIG="$*" $KUBECTL config view --flatten --merge
+      IFS=$':\n\t'
+      if [[ "$1" == '-p' || "$1" == '--preserve-structure' ]]; then
+        KUBECONFIG="${*:2}" $KUBECTL config view --raw --merge
+      else
+        KUBECONFIG="$*" $KUBECTL config view --flatten --merge
+      fi
+      IFS=$' \t\n'
     fi
 }
 
@@ -89,7 +92,7 @@ import_ctx() {
     elif [[ "${1}" =~ ^-(.*) ]]; then
       error "unrecognized flag \"$1\""
     fi
-    tmpcfg=$(mktemp konfig_XXX)
+    tmpcfg=$(mktemp konfig_XXXXXX)
     TMPFILES+=( "$tmpcfg" )
     $KUBECTL config view --flatten > "$tmpcfg"
 
@@ -123,13 +126,15 @@ export_contexts() {
     fi
 
     for x in "${ctxs[@]}"; do
-      tmpcfg=$(mktemp konfig_XXX)
+      tmpcfg=$(mktemp konfig_XXXXXX)
       TMPFILES+=( "$tmpcfg" )
       tmpcfgs+=( "$tmpcfg" )
       if [[ "${#cfgs[@]}" -eq 0 ]]; then
         $KUBECTL config view --flatten --minify --context="$x" > "$tmpcfg"
       else
+        IFS=$':\n\t'
         KUBECONFIG="${cfgs[*]}" $KUBECTL config view --flatten --minify --context="$x" > "$tmpcfg"
+        IFS=$' \n\t'
       fi
     done
 


### PR DESCRIPTION
When IFS does not contain ' ', bash-3 does not read CLI arguments as separate words, but passes them as one word instead. Therefore, restrict `IFS=':\t\n'` to the region where absolutely necessary.

Fix #7 