### PR TITLE
Fix krew link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The recommended installation method is via `krew`.
 
 ### Via krew
 Krew is the `kubectl` plugin manager. If you have not yet installed `krew`, get it at
-[https://github.com/GoogleContainerTools/krew](https://github.com/GoogleContainerTools/krew).
+[https://github.com/kubernetes-sigs/krew](https://github.com/kubernetes-sigs/krew).
 Then installation is as simple as
 ```bash
 kubectl krew install konfig


### PR DESCRIPTION
krew is now hosted at https://github.com/kubernetes-sigs/krew