### PR TITLE
Handle read errors when importing kubeconfig

### DIFF
--- a/konfig
+++ b/konfig
@@ -16,7 +16,7 @@
 
 [[ -n $DEBUG ]] && set -x
 
-set -eou pipefail
+set -eEuo pipefail
 
 declare -a TMPFILES=()
 cleanup() {
@@ -104,6 +104,7 @@ import_ctx() {
     if [[ -z "$out" ]]; then
       merge "$arg" "$tmpcfg" "$@"
     else
+      trap 'mv "$tmpcfg" "$out"' ERR
       merge "$arg" "$tmpcfg" "$@" > "$out"
     fi
 }

--- a/test/konfig.bats
+++ b/test/konfig.bats
@@ -121,6 +121,16 @@ load common
   [[ $(check_kubeconfig 'testdata/config123') = 'same' ]]
 }
 
+@test "failed read of imported config should preserve .kube/config" {
+  use_config config1
+  chmod u-r testdata/config-2
+  run ${COMMAND} import -s /does/not/exist testdata/config-2
+  chmod u+r testdata/config-2
+  echo "$output"
+  [[ "$status" -eq 1 ]]
+  [[ $(check_kubeconfig 'testdata/config1') = 'same' ]]
+}
+
 ####  EXPORT
 
 @test "exporting with '--kubeconfig' yields original config - I" {


### PR DESCRIPTION
Importing a config into the current kubeconfig can fail if the imported
config is not readable. This used to truncate the kubeconfig .. oops!
Now the original kubeconfig is always restored on errors after entering
the critical section.

Fix #26 