### PR TITLE
Add support to import from stdin

### DIFF
--- a/konfig
+++ b/konfig
@@ -35,9 +35,10 @@ USAGE:
      Merge multiple kubeconfigs into one.
      -p  prevents flattening which will make the result less portable.
 
-  konfig import [--preserve-structure,-p] [--save,-s] <CONFIG>..
+  konfig import [--preserve-structure,-p] [--save,-s] [--stdin,-i] <CONFIG>..
      Import the given configs into your current kubeconfig (respects KUBECONFIG env var).
      -s  writes the result to your ~/.kube/config
+     -i  import kubeconfig string from stdin
 
   konfig split  <CONTEXT>.. [--kubeconfig,-k <CONFIG>]
   konfig export <CONTEXT>.. [--kubeconfig,-k <CONFIG>]
@@ -84,28 +85,47 @@ merge() {
 }
 
 import_ctx() {
+    declare -a tmpcfgs=()
     local tmpcfg
+    local tmpinputcfg=""
     local out=""
     local arg=""
-    if [[ "$1" == '-p' || "$1" == '--preserve-structure' ]]; then
-      arg="$1"
-      shift
-    fi
-    if [[ "$1" = '--save' || "$1" = '-s' ]]; then
-      out="${XDG_CACHE_HOME:-$HOME/.kube}/config"
-      shift
-    elif [[ "$1" =~ ^-(.*) ]]; then
-      error "unrecognized flag \"$1\""
-    fi
+
     tmpcfg=$(mktemp konfig_XXXXXX)
     TMPFILES+=( "$tmpcfg" )
+    tmpcfgs+=( "$tmpcfg")
+
+    for OPT in "$@"; do
+      case $OPT in
+        -p | --preserve-structure)
+          arg="$1"
+          shift
+          ;;
+        -s | --save)
+          out="${XDG_CACHE_HOME:-$HOME/.kube}/config"
+          shift
+          ;;
+        -i | --stdin)
+          if [[ -p /dev/stdin ]]; then
+            tmpinputcfg=$(mktemp konfig_input_XXXXXX)
+            TMPFILES+=( "$tmpinputcfg" )
+            tmpcfgs+=( "$tmpinputcfg" )
+            cat - > "$tmpinputcfg"
+            shift
+          fi
+          ;;
+        -*)
+          error "unrecognized flag \"$1\""
+          ;;
+      esac
+    done
     $KUBECTL config view --raw > "$tmpcfg"
 
     if [[ -z "$out" ]]; then
-      merge "$arg" "$tmpcfg" "$@"
+      merge "$arg" "${tmpcfgs[@]}" "$@"
     else
       trap 'mv "$tmpcfg" "$out"' ERR
-      merge "$arg" "$tmpcfg" "$@" > "$out"
+      merge "$arg" "${tmpcfgs[@]}" "$@" > "$out"
     fi
 }
 

--- a/test/konfig.bats
+++ b/test/konfig.bats
@@ -121,6 +121,37 @@ load common
   [[ $(check_kubeconfig 'testdata/config123') = 'same' ]]
 }
 
+@test "import single config from stdin and print to stdout" {
+  use_config config1
+  run bash -c "cat testdata/config3 | ${COMMAND} import -i"
+  echo "$output"
+  [[ "$status" -eq 0 ]]
+  [[ $(check_fixture 'testdata/config13-flat' "$output") = 'same' ]]
+}
+
+@test "import single config from stdin" {
+  use_config config1
+  run bash -c "cat testdata/config3 | ${COMMAND} import -i --save"
+  echo "$output"
+  [[ "$status" -eq 0 ]]
+  [[ $(check_kubeconfig 'testdata/config13-flat') = 'same' ]]
+}
+
+@test "import no stdin should preserve .kube/config" {
+  use_config config1
+  run ${COMMAND} import -i --save
+  [[ "$status" -eq 0 ]]
+  [[ $(check_kubeconfig 'testdata/config1') = 'same' ]]
+}
+
+@test "import invalid file from stdin should preserve .kube/config" {
+  use_config config1
+  run bash -c "echo invalid | ${COMMAND} import -i --save"
+  echo "$output"
+  [[ "$status" -eq 1 ]]
+  [[ $(check_kubeconfig 'testdata/config1') = 'same' ]]
+}
+
 @test "failed read of imported config should preserve .kube/config" {
   use_config config1
   chmod u-r testdata/config-2

--- a/test/testdata/config13-flat
+++ b/test/testdata/config13-flat
@@ -1,0 +1,31 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: X19kdW1teS1jYS5jcnRfX2RhdGFfXwo=
+    server: cluster.flat
+  name: config-flat
+- cluster:
+    certificate-authority-data: Y2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGE=
+    server: cluster.passwd
+  name: config-passwd
+contexts:
+- context:
+    cluster: config-flat
+    user: config-flat
+  name: context1
+- context:
+    cluster: config-passwd
+    user: config-passwd
+  name: context3
+current-context: context1
+kind: Config
+preferences: {}
+users:
+- name: config-flat
+  user:
+    client-certificate-data: X19kdW1teS1jbGllbnQuY3J0X19kYXRhX18K
+    client-key-data: X19kdW1teS1jbGllbnQua2V5X19kYXRhX18K
+- name: config-passwd
+  user:
+    password: not-a-secure-password
+    username: admin


### PR DESCRIPTION
Thsi Adds support to import kubeconfig string from stdin.
It enables to import kubeconfig in clusterAPI case like below
```
clusterctl get kubeconfig k8s1 | konfig import -i 
```

At the same time, I changed  ubuntu image to 18.04 as duggan/bats repo doesn't exist for focal for now.