### PR TITLE
Fix CI as the latest ubuntu image uses 20.04 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,10 @@ jobs:
     - name: Run tests
       run: |
          set -euo pipefail
-         sudo add-apt-repository ppa:duggan/bats --yes
          sudo apt-get update -qq
          sudo apt-get install -qq bats
-         sudo curl -fsSL -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.19.2/bin/linux/amd64/kubectl
-         sudo chmod +x /usr/bin/kubectl
+         # To make 'no kubectl detected' test work, move kubectl to /usr/local/bin/
+         sudo mv /bin/kubectl /usr/local/bin/kubectl
          make test
 
     - name: Create assets


### PR DESCRIPTION
The following change is included in this commit.

- Install bats from ubuntu repo
- Delete kubectl installation as kubectl is pre-installed now
- In order to make "no kubectl detected" test work, pre-installed kubectl is moved to /usr/local/bin
  It's because /bin is link to /usr/bin.

Signed-off-by: Yuki Tsuboi <ytsuboi@vmware.com>