### PR TITLE
Remove less pager from usage call

### DIFF
--- a/konfig
+++ b/konfig
@@ -178,13 +178,13 @@ main() {
   fi
 
   if [[ "$#" -eq 0 ]]; then
-    usage | less
+    usage
     return
   fi
 
   case "$1" in
   '-h' | '--help' | 'help')
-    usage | less
+    usage
     ;;
   'export'|'split')
     export_contexts "${@:2}"


### PR DESCRIPTION
Please let the user decide, whether or not they want to pipe usage output to a pager.

I believe this is some debugging left-over from https://github.com/corneliusweig/konfig/commit/b5d83c80c9bd1e9e48ec2a14f8616d573f2c8c6b