### PR TITLE
fix: Use a custom test env var instead of XDG_CACHE_HOME

### DIFF
--- a/konfig
+++ b/konfig
@@ -102,7 +102,7 @@ import_ctx() {
           shift
           ;;
         -s | --save)
-          out="${XDG_CACHE_HOME:-$HOME/.kube}/config"
+          out="${KONFIG_TEST_DIR:-$HOME/.kube}/config"
           shift
           ;;
         -i | --stdin)

--- a/test/common.bash
+++ b/test/common.bash
@@ -16,13 +16,13 @@
 
 # bats setup function
 setup() {
-  export XDG_CACHE_HOME="$(mktemp -d)"
-  export KUBECONFIG="${XDG_CACHE_HOME}/config"
+  export KONFIG_TEST_DIR="$(mktemp -d)"
+  export KUBECONFIG="${KONFIG_TEST_DIR}/config"
 }
 
 # bats teardown function
 teardown() {
-  rm -rf "$XDG_CACHE_HOME"
+  rm -rf "$KONFIG_TEST_DIR"
 }
 
 use_config() {
@@ -30,7 +30,7 @@ use_config() {
 }
 
 check_kubeconfig() {
-  diff -U3 "${1}" "${XDG_CACHE_HOME}/config" && echo 'same' || echo 'different'
+  diff -U3 "${1}" "${KONFIG_TEST_DIR}/config" && echo 'same' || echo 'different'
 }
 
 check_fixture() {


### PR DESCRIPTION
Third time's the charm. Apologies for the noise.

Since none of the XDG_ directories work with kubectl, since kubectl unfortunately does not respect them, I removed `XDG_CACHE_HOME` entirely. Since the tests rely on it, I replaced it with a custom environment variable.